### PR TITLE
refactor(web)!: use extractor fromPublished function

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,13 +53,17 @@ The heart of the program is arguably the recursive type extractor `fromType` fol
 
 - There is a `quokka` directory used to live-edit (run code as you type it) example code snippets. Think of this as a little sandbox for development. To take full advantage you'll need Quokka VSCode plugin.
 
-- `yarn -s dev:test` gives fast feedback with many simple unit tests.
-
 - https://ts-ast-viewer.com can be extremely help when trying to get a birds eye view of the AST. Sometimes you see data that you wish you were shown the API navigation calls to get it. But even without that it is still very handy to at least get a sense.
 
 - Amazing use-case for [Quokka.js](https://quokkajs.com/) if you have it. Set yourself up a test module using techniques like those seen in `test/setup.ts` and get the best possible feedback loop going!
 
 - Very little information about the TS AST seems available. There is [the Wiki](https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API) and a bit of information here https://sandersn.github.io/manual/Typescript-compiler-implementation.html. Also here: https://basarat.gitbook.io/typescript/overview (but this has not been updated for a long time).
+
+- Tydoc uses [debug](https://github.com/visionmedia/debug). When enabled via `*` it also causes Oclif to render stack traces for unexpected thrown errors.
+
+  ```
+  DEBUG=* tydoc ...
+  ```
 
 ## Testing
 

--- a/packages/extractor/README.md
+++ b/packages/extractor/README.md
@@ -7,7 +7,6 @@ Work in progress 👷‍
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Features](#features)
 - [Features Still TODO](#features-still-todo)
 - [General Features Overview](#general-features-overview)
@@ -23,10 +22,10 @@ Work in progress 👷‍
   - [Named Exports](#named-exports)
   - [Main Export](#main-export)
 - [Type Index Overview](#type-index-overview)
-    - [Exported Types of exported terms reference the type index](#exported-types-of-exported-terms-reference-the-type-index)
-    - [Non-exported types of exported terms show up in the Type Index](#non-exported-types-of-exported-terms-show-up-in-the-type-index)
-    - [Module Level TsDoc](#module-level-tsdoc)
-    - [Qualified Module Paths](#qualified-module-paths)
+  - [Exported Types of exported terms reference the type index](#exported-types-of-exported-terms-reference-the-type-index)
+  - [Non-exported types of exported terms show up in the Type Index](#non-exported-types-of-exported-terms-show-up-in-the-type-index)
+  - [Module Level TsDoc](#module-level-tsdoc)
+  - [Qualified Module Paths](#qualified-module-paths)
   - [Avoids extracting docs for native types (Array, RegExp, etc.)](#avoids-extracting-docs-for-native-types-array-regexp-etc)
 - [TS Types Support Overview](#ts-types-support-overview)
   - [Functions](#functions)
@@ -1603,12 +1602,5 @@ export interface Settings {
 ```ts
 export type Thunk<T> = () => T
 ```
+
 <!-- END API DOCS --->
-
-## Debugging
-
-Tydoc uses [debug](https://github.com/visionmedia/debug). When enabled via `*` it also causes Oclif to render stack traces for unexpected thrown errors.
-
-```
-DEBUG=* tydoc ...
-```

--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -6,12 +6,12 @@ export default function Home() {
   return (
     <Layout>
       <ul>
-        <ListEl link="/npm/types/graphql-request" name="graphql-request" />
-        <ListEl link="/npm/src_index/swrv" name="swrv" />
-        <ListEl
-          link="/npm/src_index/@tony_win2win/common"
-          name="@tony_win2win/common"
-        />
+        <ListEl link="/npm/setset" name="setset" />
+        <ListEl link="/npm/floggy" name="floggy" />
+        <ListEl link="/npm/execa" name="execa" />
+        <ListEl link="/npm/sponsorsme" name="sponsorsme" />
+        <ListEl link="/npm/swrv" name="swrv" />
+        <ListEl link="/npm/@tony_win2win/common" name="@tony_win2win/common" />
       </ul>
     </Layout>
   )


### PR DESCRIPTION
BREAKING CHANGE:

- URL pattern changes from:

    /npm/{entrypoint}/{packageName}

  to just

    /npm/{packageName}

- The npm info extraction is lost for now, we should bring that back via
  extractor features soon.