### PR TITLE
feat(extractor): type param name & default for alias & interface

### DIFF
--- a/packages/extractor/source/doc.ts
+++ b/packages/extractor/source/doc.ts
@@ -633,7 +633,10 @@ export type TypeParameter = {
    */
   name: string
   /**
+   * The default type for this parameter.
+   *
    * @example
+   * // The default type is string
    * type Foo<A = string> = {}
    */
   default: null | Unsupported | InlineTypeOrIndexRef

--- a/packages/extractor/source/index.ts
+++ b/packages/extractor/source/index.ts
@@ -1,1 +1,2 @@
 export * from './extract'
+export * as Reader from './reader'

--- a/packages/extractor/source/lib/ts-helpers.ts
+++ b/packages/extractor/source/lib/ts-helpers.ts
@@ -188,6 +188,15 @@ export function getFirstDeclarationOrThrow(symbol: tsm.Symbol): tsm.Node {
 }
 
 /**
+ * A variant of getTargetType method that only returns if the gotten type is
+ * different than the given type. Works around https://github.com/dsherret/ts-morph/issues/904.
+ */
+export function getTargetType(t: tsm.Type) {
+  const targetType = t.getTargetType()
+  return targetType === t ? undefined : targetType
+}
+
+/**
  * Get the module path of the given source file. The difference from a file path
  * is that a module path does not have a file extension and is always in posix format.
  */

--- a/packages/extractor/source/reader.ts
+++ b/packages/extractor/source/reader.ts
@@ -1,0 +1,73 @@
+import { inspect } from 'util'
+import * as Doc from './doc'
+
+/**
+ * A fluent (aka. chaining) API for navigating the EPD.
+ */
+type Reader = {
+  get(name: string): Doc.IndexableNode
+  getInterface(name: string): Doc.Interface
+  getAlias(name: string): Doc.Alias
+  dump(): void
+}
+
+/**
+ * Create a reader. A fluent (aka. chaining) API for navigating the EPD.
+ */
+export function create(edd: Doc.Package): Reader {
+  return {
+    getInterface: getInterface.bind(null, edd),
+    getAlias: getAlias.bind(null, edd),
+    get: get.bind(null, edd),
+    dump() {
+      console.error(inspect(edd, { depth: null }))
+    },
+  }
+}
+
+/**
+ * Lookup an interface type in the type index.
+ *
+ * Throws if searched type is not in the type index.
+ * Throws if the found type is not an interface.
+ */
+export function getInterface(edd: Doc.Package, name: string): Doc.Interface {
+  const t = get(edd, name)
+
+  if (t.kind !== 'interface') {
+    throw new Error(`Expected the indexed type "${name}" to be an interface but it was actually an ${t.kind}`)
+  }
+
+  return t
+}
+
+/**
+ * Lookup an alias type in the type index.
+ *
+ * Throws if searched type is not in the type index.
+ * Throws if the found type is not an alias.
+ */
+export function getAlias(edd: Doc.Package, name: string): Doc.Alias {
+  const t = get(edd, name)
+
+  if (t.kind !== 'alias') {
+    throw new Error(`Expected the indexed type "${name}" to be an alias but it was actually an ${t.kind}`)
+  }
+
+  return t
+}
+
+/**
+ * Lookup a type in the type index.
+ *
+ * Throws if searched type is not in the type index.
+ */
+export function get(edd: Doc.Package, name: string): Doc.IndexableNode {
+  const t = edd.typeIndex[name]
+
+  if (!t) {
+    throw new Error(`Could not find type "${name}" in the type index.`)
+  }
+
+  return t
+}

--- a/packages/extractor/test/__setup__.ts
+++ b/packages/extractor/test/__setup__.ts
@@ -1,7 +1,7 @@
 import * as Path from 'path'
 import * as Prettier from 'prettier'
 import * as tsm from 'ts-morph'
-import * as jsde from '../source'
+import * as TyDoc from '../source'
 
 interface ModuleSpec {
   /**
@@ -60,7 +60,7 @@ function createContextt() {
           overwrite: true,
         })
       }
-      return jsde.fromProject({
+      return TyDoc.fromProject({
         entrypoints: entrypoints,
         layout: {
           tsMorphProject,
@@ -73,6 +73,10 @@ function createContextt() {
           },
         },
       })
+    },
+    extract2(...modules: (string | ModuleSpec)[]) {
+      const edd = api.extract(...modules)
+      return TyDoc.Reader.create(edd)
     },
   }
 

--- a/packages/extractor/test/integration/kitchen-sink.test.ts
+++ b/packages/extractor/test/integration/kitchen-sink.test.ts
@@ -325,6 +325,7 @@ it('tydoc can extract data', () => {
             "typeText": "A",
           },
           "tsdoc": null,
+          "typeParameters": Array [],
         },
         "(a).C": Object {
           "kind": "interface",
@@ -359,6 +360,7 @@ it('tydoc can extract data', () => {
             "typeText": "C",
           },
           "tsdoc": null,
+          "typeParameters": Array [],
         },
         "(b).D": Object {
           "kind": "interface",
@@ -393,6 +395,7 @@ it('tydoc can extract data', () => {
             "typeText": "D",
           },
           "tsdoc": null,
+          "typeParameters": Array [],
         },
       },
     }

--- a/packages/extractor/test/system/__snapshots__/packages.test.ts.snap
+++ b/packages/extractor/test/system/__snapshots__/packages.test.ts.snap
@@ -30,7 +30,7 @@ Object {
             "name": "CommonOptions",
             "type": Object {
               "kind": "typeIndexRef",
-              "link": "(index).CommonOptions<EncodingType>",
+              "link": "(index).CommonOptions",
             },
           },
           Object {
@@ -40,7 +40,7 @@ Object {
             "name": "Options",
             "type": Object {
               "kind": "typeIndexRef",
-              "link": "(index).Options<EncodingType>",
+              "link": "(index).Options",
             },
           },
           Object {
@@ -50,7 +50,7 @@ Object {
             "name": "SyncOptions",
             "type": Object {
               "kind": "typeIndexRef",
-              "link": "(index).SyncOptions<EncodingType>",
+              "link": "(index).SyncOptions",
             },
           },
           Object {
@@ -60,7 +60,7 @@ Object {
             "name": "NodeOptions",
             "type": Object {
               "kind": "typeIndexRef",
-              "link": "(index).NodeOptions<EncodingType>",
+              "link": "(index).NodeOptions",
             },
           },
           Object {
@@ -70,7 +70,7 @@ Object {
             "name": "ExecaReturnBase",
             "type": Object {
               "kind": "typeIndexRef",
-              "link": "(index).ExecaReturnBase<StdoutStderrType>",
+              "link": "(index).ExecaReturnBase",
             },
           },
           Object {
@@ -80,7 +80,7 @@ Object {
             "name": "ExecaSyncReturnValue",
             "type": Object {
               "kind": "typeIndexRef",
-              "link": "(index).ExecaSyncReturnValue<StdoutErrorType>",
+              "link": "(index).ExecaSyncReturnValue",
             },
           },
           Object {
@@ -90,7 +90,7 @@ Object {
             "name": "ExecaReturnValue",
             "type": Object {
               "kind": "typeIndexRef",
-              "link": "(index).ExecaReturnValue<StdoutErrorType>",
+              "link": "(index).ExecaReturnValue",
             },
           },
           Object {
@@ -100,7 +100,7 @@ Object {
             "name": "ExecaSyncError",
             "type": Object {
               "kind": "typeIndexRef",
-              "link": "(index).ExecaSyncError<StdoutErrorType>",
+              "link": "(index).ExecaSyncError",
             },
           },
           Object {
@@ -110,7 +110,7 @@ Object {
             "name": "ExecaError",
             "type": Object {
               "kind": "typeIndexRef",
-              "link": "(index).ExecaError<StdoutErrorType>",
+              "link": "(index).ExecaError",
             },
           },
           Object {
@@ -130,7 +130,7 @@ Object {
             "name": "ExecaChildPromise",
             "type": Object {
               "kind": "typeIndexRef",
-              "link": "(index).ExecaChildPromise<StdoutErrorType>",
+              "link": "(index).ExecaChildPromise",
             },
           },
           Object {
@@ -149,7 +149,7 @@ Object {
       },
     ],
     "typeIndex": Object {
-      "(index).CommonOptions<EncodingType>": Object {
+      "(index).CommonOptions": Object {
         "kind": "interface",
         "name": "CommonOptions",
         "props": Array [
@@ -1141,6 +1141,17 @@ interface ReadonlyArray<T> {
           "typeText": "CommonOptions<EncodingType>",
         },
         "tsdoc": null,
+        "typeParameters": Array [
+          Object {
+            "default": null,
+            "name": "EncodingType",
+            "raw": Object {
+              "nodeFullText": "EncodingType",
+              "nodeText": "EncodingType",
+              "typeText": "EncodingType",
+            },
+          },
+        ],
       },
       "(index).ExecaChildProcess": Object {
         "kind": "alias",
@@ -2045,8 +2056,22 @@ interface Promise<T> {
             },
           ],
         },
+        "typeParameters": Array [
+          Object {
+            "default": Object {
+              "kind": "primitive",
+              "type": "string",
+            },
+            "name": "StdoutErrorType",
+            "raw": Object {
+              "nodeFullText": "StdoutErrorType = string",
+              "nodeText": "StdoutErrorType = string",
+              "typeText": "StdoutErrorType",
+            },
+          },
+        ],
       },
-      "(index).ExecaChildPromise<StdoutErrorType>": Object {
+      "(index).ExecaChildPromise": Object {
         "kind": "interface",
         "name": "ExecaChildPromise",
         "props": Array [
@@ -2718,8 +2743,19 @@ interface Promise<T> {
           "typeText": "ExecaChildPromise<StdoutErrorType>",
         },
         "tsdoc": null,
+        "typeParameters": Array [
+          Object {
+            "default": null,
+            "name": "StdoutErrorType",
+            "raw": Object {
+              "nodeFullText": "StdoutErrorType",
+              "nodeText": "StdoutErrorType",
+              "typeText": "StdoutErrorType",
+            },
+          },
+        ],
       },
-      "(index).ExecaError<StdoutErrorType>": Object {
+      "(index).ExecaError": Object {
         "kind": "interface",
         "name": "ExecaError",
         "props": Array [
@@ -2903,8 +2939,22 @@ interface Promise<T> {
           "typeText": "ExecaError<StdoutErrorType>",
         },
         "tsdoc": null,
+        "typeParameters": Array [
+          Object {
+            "default": Object {
+              "kind": "primitive",
+              "type": "string",
+            },
+            "name": "StdoutErrorType",
+            "raw": Object {
+              "nodeFullText": "StdoutErrorType = string",
+              "nodeText": "StdoutErrorType = string",
+              "typeText": "StdoutErrorType",
+            },
+          },
+        ],
       },
-      "(index).ExecaReturnBase<StdoutStderrType>": Object {
+      "(index).ExecaReturnBase": Object {
         "kind": "interface",
         "name": "ExecaReturnBase",
         "props": Array [
@@ -3095,8 +3145,19 @@ interface Promise<T> {
           "typeText": "ExecaReturnBase<StdoutStderrType>",
         },
         "tsdoc": null,
+        "typeParameters": Array [
+          Object {
+            "default": null,
+            "name": "StdoutStderrType",
+            "raw": Object {
+              "nodeFullText": "StdoutStderrType",
+              "nodeText": "StdoutStderrType",
+              "typeText": "StdoutStderrType",
+            },
+          },
+        ],
       },
-      "(index).ExecaReturnValue<StdoutErrorType>": Object {
+      "(index).ExecaReturnValue": Object {
         "kind": "interface",
         "name": "ExecaReturnValue",
         "props": Array [
@@ -3271,8 +3332,22 @@ interface Promise<T> {
 	- being canceled
 	- there's not enough memory or there are already too many child processes",
         },
+        "typeParameters": Array [
+          Object {
+            "default": Object {
+              "kind": "primitive",
+              "type": "string",
+            },
+            "name": "StdoutErrorType",
+            "raw": Object {
+              "nodeFullText": "StdoutErrorType = string",
+              "nodeText": "StdoutErrorType = string",
+              "typeText": "StdoutErrorType",
+            },
+          },
+        ],
       },
-      "(index).ExecaSyncError<StdoutErrorType>": Object {
+      "(index).ExecaSyncError": Object {
         "kind": "interface",
         "name": "ExecaSyncError",
         "props": Array [
@@ -3447,8 +3522,22 @@ interface Promise<T> {
           "typeText": "ExecaSyncError<StdoutErrorType>",
         },
         "tsdoc": null,
+        "typeParameters": Array [
+          Object {
+            "default": Object {
+              "kind": "primitive",
+              "type": "string",
+            },
+            "name": "StdoutErrorType",
+            "raw": Object {
+              "nodeFullText": "StdoutErrorType = string",
+              "nodeText": "StdoutErrorType = string",
+              "typeText": "StdoutErrorType",
+            },
+          },
+        ],
       },
-      "(index).ExecaSyncReturnValue<StdoutErrorType>": Object {
+      "(index).ExecaSyncReturnValue": Object {
         "kind": "interface",
         "name": "ExecaSyncReturnValue",
         "props": Array [
@@ -3545,6 +3634,20 @@ interface Promise<T> {
           "typeText": "ExecaSyncReturnValue<StdoutErrorType>",
         },
         "tsdoc": null,
+        "typeParameters": Array [
+          Object {
+            "default": Object {
+              "kind": "primitive",
+              "type": "string",
+            },
+            "name": "StdoutErrorType",
+            "raw": Object {
+              "nodeFullText": "StdoutErrorType = string",
+              "nodeText": "StdoutErrorType = string",
+              "typeText": "StdoutErrorType",
+            },
+          },
+        ],
       },
       "(index).KillOptions": Object {
         "kind": "interface",
@@ -3600,8 +3703,9 @@ interface Promise<T> {
           "typeText": "KillOptions",
         },
         "tsdoc": null,
+        "typeParameters": Array [],
       },
-      "(index).NodeOptions<EncodingType>": Object {
+      "(index).NodeOptions": Object {
         "kind": "interface",
         "name": "NodeOptions",
         "props": Array [
@@ -4947,8 +5051,22 @@ interface ReadonlyArray<T> {
           "typeText": "NodeOptions<EncodingType>",
         },
         "tsdoc": null,
+        "typeParameters": Array [
+          Object {
+            "default": Object {
+              "kind": "primitive",
+              "type": "string",
+            },
+            "name": "EncodingType",
+            "raw": Object {
+              "nodeFullText": "EncodingType = string",
+              "nodeText": "EncodingType = string",
+              "typeText": "EncodingType",
+            },
+          },
+        ],
       },
-      "(index).Options<EncodingType>": Object {
+      "(index).Options": Object {
         "kind": "interface",
         "name": "Options",
         "props": Array [
@@ -6257,6 +6375,20 @@ interface ReadonlyArray<T> {
           "typeText": "Options<EncodingType>",
         },
         "tsdoc": null,
+        "typeParameters": Array [
+          Object {
+            "default": Object {
+              "kind": "primitive",
+              "type": "string",
+            },
+            "name": "EncodingType",
+            "raw": Object {
+              "nodeFullText": "EncodingType = string",
+              "nodeText": "EncodingType = string",
+              "typeText": "EncodingType",
+            },
+          },
+        ],
       },
       "(index).StdioOption": Object {
         "kind": "alias",
@@ -6344,8 +6476,9 @@ interface ReadonlyArray<T> {
             },
           ],
         },
+        "typeParameters": Array [],
       },
-      "(index).SyncOptions<EncodingType>": Object {
+      "(index).SyncOptions": Object {
         "kind": "interface",
         "name": "SyncOptions",
         "props": Array [
@@ -7439,6 +7572,20 @@ interface ReadonlyArray<T> {
           "typeText": "SyncOptions<EncodingType>",
         },
         "tsdoc": null,
+        "typeParameters": Array [
+          Object {
+            "default": Object {
+              "kind": "primitive",
+              "type": "string",
+            },
+            "name": "EncodingType",
+            "raw": Object {
+              "nodeFullText": "EncodingType = string",
+              "nodeText": "EncodingType = string",
+              "typeText": "EncodingType",
+            },
+          },
+        ],
       },
     },
   },
@@ -13414,6 +13561,7 @@ export default class Sponsors {
             "typeText": "SponsorsOptions",
           },
         },
+        "typeParameters": Array [],
       },
       "(dist/index).Sponsorship": Object {
         "kind": "alias",
@@ -13534,6 +13682,7 @@ export default class Sponsors {
             "typeText": "Sponsorship",
           },
         },
+        "typeParameters": Array [],
       },
       "(dist/index).SponsorshipSponsor": Object {
         "kind": "alias",
@@ -13606,6 +13755,7 @@ export default class Sponsors {
             "typeText": "SponsorshipSponsor",
           },
         },
+        "typeParameters": Array [],
       },
       "(dist/index).SponsorshipTier": Object {
         "kind": "alias",
@@ -13714,6 +13864,7 @@ export default class Sponsors {
             "typeText": "SponsorshipTier",
           },
         },
+        "typeParameters": Array [],
       },
     },
   },

--- a/packages/extractor/test/unit/__snapshots__/alias.spec.ts.snap
+++ b/packages/extractor/test/unit/__snapshots__/alias.spec.ts.snap
@@ -45,6 +45,7 @@ Object {
         },
         "kind": "array",
       },
+      "typeParameters": Array [],
     },
   },
 }
@@ -95,6 +96,7 @@ export type A = typeof a;",
         },
         "kind": "array",
       },
+      "typeParameters": Array [],
     },
   },
 }
@@ -141,6 +143,7 @@ Object {
         "kind": "primitive",
         "type": "boolean",
       },
+      "typeParameters": Array [],
     },
   },
 }
@@ -188,6 +191,7 @@ export type A = typeof a;",
         "kind": "primitive",
         "type": "boolean",
       },
+      "typeParameters": Array [],
     },
   },
 }
@@ -256,6 +260,7 @@ Object {
           },
         ],
       },
+      "typeParameters": Array [],
     },
   },
 }
@@ -320,6 +325,7 @@ export type A = typeof a;",
           },
         ],
       },
+      "typeParameters": Array [],
     },
   },
 }
@@ -381,6 +387,7 @@ Object {
           "typeText": "A",
         },
       },
+      "typeParameters": Array [],
     },
   },
 }
@@ -442,6 +449,7 @@ export type A = typeof a;",
           "typeText": "{ b: number; }",
         },
       },
+      "typeParameters": Array [],
     },
   },
 }

--- a/packages/extractor/test/unit/__snapshots__/extract.spec.ts.snap
+++ b/packages/extractor/test/unit/__snapshots__/extract.spec.ts.snap
@@ -48,6 +48,7 @@ Object {
         "typeText": "A",
       },
       "tsdoc": null,
+      "typeParameters": Array [],
     },
     "(a).B1": Object {
       "kind": "interface",
@@ -72,6 +73,7 @@ Object {
         "typeText": "B1",
       },
       "tsdoc": null,
+      "typeParameters": Array [],
     },
     "(a).B2": Object {
       "kind": "interface",
@@ -83,6 +85,7 @@ Object {
         "typeText": "B2",
       },
       "tsdoc": null,
+      "typeParameters": Array [],
     },
   },
 }

--- a/packages/extractor/test/unit/__snapshots__/reference-types.spec.ts.snap
+++ b/packages/extractor/test/unit/__snapshots__/reference-types.spec.ts.snap
@@ -1,0 +1,255 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`first type parameter on an alias the alias object type default is added to the type index and refererenced 1`] = `
+Array [
+  Object {
+    "default": Object {
+      "kind": "typeIndexRef",
+      "link": "(a).Bar",
+    },
+    "name": "T",
+    "raw": Object {
+      "nodeFullText": "T = Bar",
+      "nodeText": "T = Bar",
+      "typeText": "T",
+    },
+  },
+]
+`;
+
+exports[`first type parameter on an alias the alias object type default is added to the type index and refererenced 2`] = `
+Object {
+  "kind": "alias",
+  "name": "Bar",
+  "raw": Object {
+    "nodeFullText": "export type Bar = { a: 1 };",
+    "nodeText": "export type Bar = { a: 1 };",
+    "typeText": "Bar",
+  },
+  "tsdoc": null,
+  "type": Object {
+    "kind": "object",
+    "props": Array [
+      Object {
+        "kind": "prop",
+        "name": "a",
+        "type": Object {
+          "base": "number",
+          "kind": "literal",
+          "name": "1",
+        },
+      },
+    ],
+    "raw": Object {
+      "nodeFullText": "export type Bar = { a: 1 };",
+      "nodeText": "export type Bar = { a: 1 };",
+      "typeText": "Bar",
+    },
+  },
+  "typeParameters": Array [],
+}
+`;
+
+exports[`first type parameter on an alias the interface object type default is added to the type index and refererenced 1`] = `
+Array [
+  Object {
+    "default": Object {
+      "kind": "typeIndexRef",
+      "link": "(a).Bar",
+    },
+    "name": "T",
+    "raw": Object {
+      "nodeFullText": "T = Bar",
+      "nodeText": "T = Bar",
+      "typeText": "T",
+    },
+  },
+]
+`;
+
+exports[`first type parameter on an alias the interface object type default is added to the type index and refererenced 2`] = `
+Object {
+  "kind": "interface",
+  "name": "Bar",
+  "props": Array [
+    Object {
+      "kind": "prop",
+      "name": "a",
+      "type": Object {
+        "base": "number",
+        "kind": "literal",
+        "name": "1",
+      },
+    },
+  ],
+  "raw": Object {
+    "nodeFullText": "export interface Bar {
+  a: 1;
+}",
+    "nodeText": "export interface Bar {
+  a: 1;
+}",
+    "typeText": "Bar",
+  },
+  "tsdoc": null,
+  "typeParameters": Array [],
+}
+`;
+
+exports[`first type parameter on an alias the name 1`] = `
+Array [
+  Object {
+    "default": null,
+    "name": "T",
+    "raw": Object {
+      "nodeFullText": "T",
+      "nodeText": "T",
+      "typeText": "T",
+    },
+  },
+]
+`;
+
+exports[`first type parameter on an alias the primitive type default 1`] = `
+Array [
+  Object {
+    "default": Object {
+      "kind": "primitive",
+      "type": "string",
+    },
+    "name": "T",
+    "raw": Object {
+      "nodeFullText": "T = string",
+      "nodeText": "T = string",
+      "typeText": "T",
+    },
+  },
+]
+`;
+
+exports[`first type parameter on an interface the alias object type default is added to the type index and refererenced 1`] = `
+Array [
+  Object {
+    "default": Object {
+      "kind": "typeIndexRef",
+      "link": "(a).Bar",
+    },
+    "name": "T",
+    "raw": Object {
+      "nodeFullText": "T = Bar",
+      "nodeText": "T = Bar",
+      "typeText": "T",
+    },
+  },
+]
+`;
+
+exports[`first type parameter on an interface the alias object type default is added to the type index and refererenced 2`] = `
+Object {
+  "kind": "alias",
+  "name": "Bar",
+  "raw": Object {
+    "nodeFullText": "export type Bar = { a: 1 };",
+    "nodeText": "export type Bar = { a: 1 };",
+    "typeText": "Bar",
+  },
+  "tsdoc": null,
+  "type": Object {
+    "kind": "object",
+    "props": Array [
+      Object {
+        "kind": "prop",
+        "name": "a",
+        "type": Object {
+          "base": "number",
+          "kind": "literal",
+          "name": "1",
+        },
+      },
+    ],
+    "raw": Object {
+      "nodeFullText": "export type Bar = { a: 1 };",
+      "nodeText": "export type Bar = { a: 1 };",
+      "typeText": "Bar",
+    },
+  },
+  "typeParameters": Array [],
+}
+`;
+
+exports[`first type parameter on an interface the interface object type default is added to the type index and refererenced 1`] = `
+Array [
+  Object {
+    "default": Object {
+      "kind": "typeIndexRef",
+      "link": "(a).Bar",
+    },
+    "name": "T",
+    "raw": Object {
+      "nodeFullText": "T = Bar",
+      "nodeText": "T = Bar",
+      "typeText": "T",
+    },
+  },
+]
+`;
+
+exports[`first type parameter on an interface the interface object type default is added to the type index and refererenced 2`] = `
+Object {
+  "kind": "interface",
+  "name": "Bar",
+  "props": Array [
+    Object {
+      "kind": "prop",
+      "name": "a",
+      "type": Object {
+        "base": "number",
+        "kind": "literal",
+        "name": "1",
+      },
+    },
+  ],
+  "raw": Object {
+    "nodeFullText": "export interface Bar {
+  a: 1;
+}",
+    "nodeText": "export interface Bar {
+  a: 1;
+}",
+    "typeText": "Bar",
+  },
+  "tsdoc": null,
+  "typeParameters": Array [],
+}
+`;
+
+exports[`first type parameter on an interface the name 1`] = `
+Array [
+  Object {
+    "default": null,
+    "name": "T",
+    "raw": Object {
+      "nodeFullText": "T",
+      "nodeText": "T",
+      "typeText": "T",
+    },
+  },
+]
+`;
+
+exports[`first type parameter on an interface the primitive type default 1`] = `
+Array [
+  Object {
+    "default": Object {
+      "kind": "primitive",
+      "type": "string",
+    },
+    "name": "T",
+    "raw": Object {
+      "nodeFullText": "T = string",
+      "nodeText": "T = string",
+      "typeText": "T",
+    },
+  },
+]
+`;

--- a/packages/extractor/test/unit/__snapshots__/type-alias-object.spec.ts.snap
+++ b/packages/extractor/test/unit/__snapshots__/type-alias-object.spec.ts.snap
@@ -86,6 +86,7 @@ Object {
           "typeText": "A",
         },
       },
+      "typeParameters": Array [],
     },
     "(a).B": Object {
       "kind": "alias",
@@ -114,6 +115,7 @@ Object {
           "typeText": "B",
         },
       },
+      "typeParameters": Array [],
     },
   },
 }
@@ -198,6 +200,7 @@ Object {
           "typeText": "A",
         },
       },
+      "typeParameters": Array [],
     },
     "(a).B": Object {
       "kind": "alias",
@@ -240,6 +243,7 @@ Object {
           "typeText": "B",
         },
       },
+      "typeParameters": Array [],
     },
   },
 }
@@ -300,6 +304,7 @@ Object {
           "typeText": "A",
         },
       },
+      "typeParameters": Array [],
     },
   },
 }

--- a/packages/extractor/test/unit/__snapshots__/union.spec.ts.snap
+++ b/packages/extractor/test/unit/__snapshots__/union.spec.ts.snap
@@ -62,6 +62,7 @@ Object {
               "kind": "typeIndexRef",
               "link": "(a).B",
             },
+            "typeParameters": Array [],
           },
           Object {
             "kind": "alias",
@@ -76,9 +77,11 @@ Object {
               "kind": "typeIndexRef",
               "link": "(a).C",
             },
+            "typeParameters": Array [],
           },
         ],
       },
+      "typeParameters": Array [],
     },
     "(a).B": Object {
       "kind": "alias",
@@ -117,6 +120,7 @@ Object {
           "typeText": "B",
         },
       },
+      "typeParameters": Array [],
     },
     "(a).C": Object {
       "kind": "alias",
@@ -155,6 +159,7 @@ Object {
           "typeText": "C",
         },
       },
+      "typeParameters": Array [],
     },
   },
 }
@@ -219,6 +224,7 @@ Object {
           },
         ],
       },
+      "typeParameters": Array [],
     },
     "(a).B": Object {
       "kind": "interface",
@@ -255,6 +261,7 @@ Object {
         "typeText": "B",
       },
       "tsdoc": null,
+      "typeParameters": Array [],
     },
     "(a).C": Object {
       "kind": "interface",
@@ -291,6 +298,7 @@ Object {
         "typeText": "C",
       },
       "tsdoc": null,
+      "typeParameters": Array [],
     },
   },
 }
@@ -359,6 +367,7 @@ Object {
               "kind": "typeIndexRef",
               "link": "(a).B",
             },
+            "typeParameters": Array [],
           },
           Object {
             "kind": "alias",
@@ -373,9 +382,11 @@ Object {
               "kind": "typeIndexRef",
               "link": "(a).C",
             },
+            "typeParameters": Array [],
           },
         ],
       },
+      "typeParameters": Array [],
     },
     "(a).B": Object {
       "kind": "alias",
@@ -423,6 +434,7 @@ Object {
           "typeText": "B",
         },
       },
+      "typeParameters": Array [],
     },
     "(a).C": Object {
       "kind": "alias",
@@ -470,6 +482,7 @@ Object {
           "typeText": "C",
         },
       },
+      "typeParameters": Array [],
     },
   },
 }
@@ -535,6 +548,7 @@ Object {
           },
         ],
       },
+      "typeParameters": Array [],
     },
     "(a).B": Object {
       "kind": "interface",
@@ -582,6 +596,7 @@ Object {
         "typeText": "B",
       },
       "tsdoc": null,
+      "typeParameters": Array [],
     },
     "(a).C": Object {
       "kind": "interface",
@@ -629,6 +644,7 @@ Object {
         "typeText": "C",
       },
       "tsdoc": null,
+      "typeParameters": Array [],
     },
   },
 }
@@ -693,6 +709,7 @@ Object {
           },
         ],
       },
+      "typeParameters": Array [],
     },
   },
 }

--- a/packages/extractor/test/unit/alias.spec.ts
+++ b/packages/extractor/test/unit/alias.spec.ts
@@ -66,6 +66,7 @@ it('raw is based on type alias declaration node', () => {
               "typeText": "A",
             },
           },
+          "typeParameters": Array [],
         },
       },
     }
@@ -119,6 +120,7 @@ it('exported type alias of number is added to type index', () => {
             "kind": "literal",
             "name": "1",
           },
+          "typeParameters": Array [],
         },
       },
     }
@@ -174,6 +176,7 @@ it('exported type alias of number via typeof is added to type index', () => {
             "kind": "literal",
             "name": "1",
           },
+          "typeParameters": Array [],
         },
       },
     }

--- a/packages/extractor/test/unit/array.spec.ts
+++ b/packages/extractor/test/unit/array.spec.ts
@@ -46,6 +46,7 @@ it('passes smoke test', () => {
             },
             "kind": "array",
           },
+          "typeParameters": Array [],
         },
       },
     }

--- a/packages/extractor/test/unit/extract.spec.ts
+++ b/packages/extractor/test/unit/extract.spec.ts
@@ -264,6 +264,7 @@ it('passes smoke test', () => {
             "typeText": "D",
           },
           "tsdoc": null,
+          "typeParameters": Array [],
         },
         "(a).E": Object {
           "kind": "interface",
@@ -331,6 +332,7 @@ it('passes smoke test', () => {
             "typeText": "E",
           },
           "tsdoc": null,
+          "typeParameters": Array [],
         },
         "(a).F": Object {
           "kind": "alias",
@@ -350,6 +352,7 @@ it('passes smoke test', () => {
               "typeText": "F",
             },
           },
+          "typeParameters": Array [],
         },
         "(a).F5": Object {
           "kind": "alias",
@@ -378,6 +381,7 @@ it('passes smoke test', () => {
               "typeText": "F5",
             },
           },
+          "typeParameters": Array [],
         },
         "(a).G": Object {
           "kind": "alias",
@@ -441,6 +445,7 @@ it('passes smoke test', () => {
               "typeText": "G",
             },
           },
+          "typeParameters": Array [],
         },
         "(a).H": Object {
           "kind": "alias",
@@ -472,6 +477,7 @@ it('passes smoke test', () => {
               "typeText": "H",
             },
           },
+          "typeParameters": Array [],
         },
         "(a).H2": Object {
           "kind": "interface",
@@ -483,6 +489,7 @@ it('passes smoke test', () => {
             "typeText": "H2",
           },
           "tsdoc": null,
+          "typeParameters": Array [],
         },
         "(a).I": Object {
           "kind": "alias",
@@ -519,6 +526,7 @@ it('passes smoke test', () => {
               },
             ],
           },
+          "typeParameters": Array [],
         },
         "(a).K": Object {
           "kind": "alias",
@@ -570,6 +578,7 @@ it('passes smoke test', () => {
               },
             ],
           },
+          "typeParameters": Array [],
         },
         "(a).L": Object {
           "kind": "alias",
@@ -667,6 +676,7 @@ it('passes smoke test', () => {
               },
             ],
           },
+          "typeParameters": Array [],
         },
         "(a).M": Object {
           "kind": "alias",
@@ -686,6 +696,7 @@ it('passes smoke test', () => {
               "typeText": "M",
             },
           },
+          "typeParameters": Array [],
         },
         "(a).N1": Object {
           "kind": "alias",
@@ -714,6 +725,7 @@ it('passes smoke test', () => {
               "typeText": "N1",
             },
           },
+          "typeParameters": Array [],
         },
         "(a).N2": Object {
           "kind": "alias",
@@ -731,6 +743,7 @@ it('passes smoke test', () => {
             },
             "kind": "array",
           },
+          "typeParameters": Array [],
         },
         "(a).N3": Object {
           "kind": "alias",
@@ -776,6 +789,7 @@ it('passes smoke test', () => {
               },
             ],
           },
+          "typeParameters": Array [],
         },
       },
     }

--- a/packages/extractor/test/unit/interface.spec.ts
+++ b/packages/extractor/test/unit/interface.spec.ts
@@ -74,3 +74,15 @@ describe('can be a named export', () => {
     ])
   })
 })
+
+// describe('bugs', () => {
+//   it('interface with generic method returning interface does not infinitely loop', () => {
+//     expect(
+//       ctx.extract(/* ts */ `
+//         export interface Foo<T> {
+//           bar: Foo<1>
+//         }
+//       `)
+//     ).toMatchInlineSnapshot(`[Function]`)
+//   })
+// })

--- a/packages/extractor/test/unit/intersection.spec.ts
+++ b/packages/extractor/test/unit/intersection.spec.ts
@@ -86,6 +86,7 @@ it('gets each member of the intersection', () => {
               },
             ],
           },
+          "typeParameters": Array [],
         },
       },
     }
@@ -197,6 +198,7 @@ it('gets each member of the intersection when inside a union', () => {
               },
             ],
           },
+          "typeParameters": Array [],
         },
       },
     }

--- a/packages/extractor/test/unit/reference-types.spec.ts
+++ b/packages/extractor/test/unit/reference-types.spec.ts
@@ -1,0 +1,67 @@
+describe('first type parameter on an interface', () => {
+  it('the name', () => {
+    const edd = ctx.extract2(/* ts */ `
+      export interface Foo<T> {}
+    `)
+    expect(edd.getInterface('(a).Foo').typeParameters).toMatchSnapshot()
+  })
+
+  it('the primitive type default', () => {
+    const edd = ctx.extract2(/* ts */ `
+      export interface Foo<T = string> {}
+    `)
+    expect(edd.getInterface('(a).Foo').typeParameters).toMatchSnapshot()
+  })
+
+  it('the alias object type default is added to the type index and refererenced', () => {
+    const edd = ctx.extract2(/* ts */ `
+      export type Bar = { a: 1 }
+      export interface Foo<T = Bar> {}
+    `)
+    expect(edd.getInterface('(a).Foo').typeParameters).toMatchSnapshot()
+    expect(edd.getAlias('(a).Bar')).toMatchSnapshot()
+  })
+
+  it('the interface object type default is added to the type index and refererenced', () => {
+    const edd = ctx.extract2(/* ts */ `
+      export interface Bar { a: 1 }
+      export interface Foo<T = Bar> {}
+    `)
+    expect(edd.getInterface('(a).Foo').typeParameters).toMatchSnapshot()
+    expect(edd.getInterface('(a).Bar')).toMatchSnapshot()
+  })
+})
+
+describe('first type parameter on an alias', () => {
+  it('the name', () => {
+    const edd = ctx.extract2(/* ts */ `
+      export type Foo<T> = {}
+    `)
+    expect(edd.getAlias('(a).Foo').typeParameters).toMatchSnapshot()
+  })
+
+  it('the primitive type default', () => {
+    const edd = ctx.extract2(/* ts */ `
+      export type Foo<T = string> = {}
+    `)
+    expect(edd.getAlias('(a).Foo').typeParameters).toMatchSnapshot()
+  })
+
+  it('the alias object type default is added to the type index and refererenced', () => {
+    const edd = ctx.extract2(/* ts */ `
+      export type Bar = { a: 1 }
+      export type Foo<T = Bar> = {}
+    `)
+    expect(edd.getAlias('(a).Foo').typeParameters).toMatchSnapshot()
+    expect(edd.getAlias('(a).Bar')).toMatchSnapshot()
+  })
+
+  it('the interface object type default is added to the type index and refererenced', () => {
+    const edd = ctx.extract2(/* ts */ `
+      export interface Bar { a: 1 }
+      export type Foo<T = Bar> = {}
+    `)
+    expect(edd.getAlias('(a).Foo').typeParameters).toMatchSnapshot()
+    expect(edd.getInterface('(a).Bar')).toMatchSnapshot()
+  })
+})

--- a/packages/extractor/test/unit/tsdoc.spec.ts
+++ b/packages/extractor/test/unit/tsdoc.spec.ts
@@ -73,6 +73,7 @@ it('interfaces can have tsdoc', () => {
      */",
             "summary": "...",
           },
+          "typeParameters": Array [],
         },
       },
     }
@@ -146,6 +147,7 @@ it('exported type aliases can have tsdoc', () => {
               "typeText": "A",
             },
           },
+          "typeParameters": Array [],
         },
       },
     }
@@ -217,6 +219,7 @@ it('type aliases can have tsdoc', () => {
               "typeText": "A",
             },
           },
+          "typeParameters": Array [],
         },
         "(a).B": Object {
           "kind": "alias",
@@ -249,6 +252,7 @@ it('type aliases can have tsdoc', () => {
               "typeText": "B",
             },
           },
+          "typeParameters": Array [],
         },
       },
     }

--- a/packages/extractor/test/unit/typeof.spec.ts
+++ b/packages/extractor/test/unit/typeof.spec.ts
@@ -87,6 +87,7 @@ it('inlines the type extracted from the term', () => {
             "typeText": "A",
           },
           "tsdoc": null,
+          "typeParameters": Array [],
         },
         "(a).B": Object {
           "kind": "interface",
@@ -98,6 +99,7 @@ it('inlines the type extracted from the term', () => {
             "typeText": "B",
           },
           "tsdoc": null,
+          "typeParameters": Array [],
         },
       },
     }

--- a/packages/web/stories/fixtures.ts
+++ b/packages/web/stories/fixtures.ts
@@ -1,6 +1,11 @@
-import { Doc } from '@tydoc/extractor/types'
+// todo:
+// Restore this once we're able to extract graphql request
+// docs again with extractor (current hitting infinite loop)
+//
+// import { Doc } from '@tydoc/extractor/types'
+// export const graphQLRequestTypes: Doc.Package = {
 
-export const graphQLRequestTypes: Doc.Package = {
+export const graphQLRequestTypes: any = {
   modules: [
     {
       kind: 'module',


### PR DESCRIPTION
Extract type parameter name and default types for interfaces and aliases.

- Does not handle type parameter constraints.
- Does not handle type parameters on methods.
- Does not handle type parameters on functions.
- Does not handle type parameters on classes.
